### PR TITLE
Added benchmarks

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -1,0 +1,32 @@
+var bitmeddler = require('./main')
+
+function bm(size)
+{
+    var bm = new bitmeddler(size);
+    var next;
+
+    while (next) next = bm.next();
+}
+
+function naive(size)
+{
+    var ary = [];
+    var i = 1;
+    var next, rand;
+
+    while (size >= i) ary.push(i++);
+
+    while (size--)
+    {
+        rand = Math.floor(Math.random() * ary.length);
+        next = ary.splice(rand, 1)[0];
+    }
+}
+
+console.time('bm');
+bm(10000);
+console.timeEnd('bm');
+
+console.time('naive');
+naive(10000);
+console.timeEnd('naive');


### PR DESCRIPTION
I was interested to see exactly how this performed against a naive implementation with arrays. The answer was: "well", unsurprisingly!

The greater the size the bigger the margin (as you mention in the README), this is what I got for 10,000 elements:

```
bm: 0.166ms
naive: 10.525ms
```

For 100 elements, 'naive' actually does better (weird, right?).

Could be useful for people trying to understand the library to have this for comparison.